### PR TITLE
Add template support to rule match patterns

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,26 @@ rules:
 - `event` (optional): `pre` (default) or `post`
 - `sources` (optional): Field names to match, empty = all fields
 
+### Template Patterns
+
+Patterns support template variables for dynamic matching:
+
+```yaml
+rules:
+  # Block bumpers.yml access in project root but allow test files
+  - match: "^{{.ProjectRoot}}/bumpers\\.yml$"
+    tool: "Read|Edit|Grep"
+    send: "Bumpers configuration file should not be accessed."
+```
+
+**Available Variables:**
+- `{{.ProjectRoot}}`: Project root directory path
+- `{{.Today}}`: Current date (YYYY-MM-DD format)
+
+**Template/Regex Compatibility:**
+- Templates use `{{}}` syntax, regex quantifiers use `{}`
+- Fully compatible: `{{.ProjectRoot}}/[a-z]{2,4}/config\\.yml`
+
 ### Tool Filter
 
 ```yaml

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -156,4 +156,36 @@ session:
       {{else if testPath "Cargo.toml"}}Rust project{{end}}
 ```
 
+### Template Patterns
+
+Dynamic pattern matching using project context:
+
+```yaml
+rules:
+  # Block main config but allow test configs
+  - match: "^{{.ProjectRoot}}/bumpers\\.yml$"
+    tool: "Read|Edit|Grep"  
+    send: "Main configuration should not be accessed directly"
+
+  # Project-specific file patterns
+  - match: "{{.ProjectRoot}}/(test|spec).*\\.yml$"
+    tool: "Read|Edit"
+    send: "Test configurations can be modified freely"
+    
+  # Mixed template variables and regex quantifiers
+  - match: "^{{.ProjectRoot}}/[a-z]{2,4}/config\\.json$"
+    tool: "Write"
+    send: "Language-specific configs: {{.Command}}"
+
+  # Environment-aware patterns  
+  - match: "{{.ProjectRoot}}/prod"
+    send: "Production files require extra care ({{.Today}})"
+```
+
+**Use Cases:**
+- **Project-specific blocking**: Target files by full path
+- **Test file exceptions**: Allow test configs while blocking main ones  
+- **Environment awareness**: Different rules for prod vs dev files
+- **Flexible matching**: Combine templates with regex for powerful patterns
+
 This configuration reference reflects the actual Bumpers implementation and avoids unsupported features.


### PR DESCRIPTION
## Summary
Implements GitHub issue #16 by adding template support to rule match patterns, enabling dynamic pattern matching using template variables for precise file targeting.

## Key Changes
- **Template Pattern Processing**: Rules can now use template variables like `{{.ProjectRoot}}` in their match patterns
- **New API**: Added `MatchWithContext` method to `RuleMatcher` for template processing  
- **Context Integration**: Updated `App` methods to pass project context through matching chain
- **Backward Compatibility**: All existing static patterns continue to work unchanged
- **Comprehensive Testing**: Full unit and integration test coverage

## Template Pattern Examples
```yaml
# Block main config but allow test configs
rules:
  - match: "^{{.ProjectRoot}}/bumpers\\.yml$"
    tool: "Read|Edit|Grep"  
    send: "Main configuration should not be accessed directly"

  # Project-specific file patterns with regex quantifiers
  - match: "^{{.ProjectRoot}}/[a-z]{2,4}/config\\.json$"
    tool: "Write"
    send: "Language-specific configs: {{.Command}}"
```

## Technical Implementation
- **Template Processing**: Uses Go's `text/template` package for variable expansion before regex compilation
- **Context Variables**: Currently supports `ProjectRoot` with extensible design for future variables
- **Error Handling**: Graceful fallback to static patterns if template processing fails
- **Performance**: Template processing only occurs when context is provided

## Test Coverage
- ✅ Unit tests for core matcher functionality
- ✅ Integration tests for end-to-end workflow  
- ✅ Template/regex compatibility validation
- ✅ Error handling and edge cases
- ✅ All existing tests continue to pass

## Documentation
- Updated `docs/configuration.md` with template pattern reference
- Added practical examples in `docs/examples.md`
- Comprehensive inline code documentation

Resolves #16